### PR TITLE
Remove notifications dropdown from admin header

### DIFF
--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -107,29 +107,7 @@ export function AdminHeader() {
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="relative">
-                <Bell className="h-5 w-5" />
-                <span className="absolute right-1 top-1 flex h-2 w-2 rounded-full bg-primary"></span>
-                <span className="sr-only">Notifications</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuLabel>Notifications</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem>
-                New comment on &quot;Global Climate Summit&quot;
-              </DropdownMenuItem>
-              <DropdownMenuItem>
-                New user registration: john.doe@example.com
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem className="text-center text-sm text-muted-foreground">
-                View all notifications
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+
           <ModeToggle />
         </div>
       </div>


### PR DESCRIPTION
Eliminate the notifications dropdown from the admin header to streamline the interface.